### PR TITLE
Use double quotes for cURL

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -66,17 +66,17 @@ resource null_resource "notify_bridgecrew" {
 
   provisioner "local-exec" {
     command = <<CURL
-      curl --request PUT 'https://www.bridgecrew.cloud/api/v1/integrations/csp' \
-      --header 'Authorization: ${var.bridgecrew_token}' \
-      --header 'Content-Type: application/json' \
-      --data-raw '${jsonencode({"customerName": var.org_name,
+      curl --request PUT "https://www.bridgecrew.cloud/api/v1/integrations/csp" \
+      --header "Authorization: ${var.bridgecrew_token}" \
+      --header "Content-Type: application/json" \
+      --data-raw "${jsonencode({"customerName": var.org_name,
                                 "version": local.version,
                                 "credentials": {
                                 "subscriptionId":   data.azurerm_subscription.subscription.subscription_id,
                                 "subscriptionName": data.azurerm_subscription.subscription.display_name,
                                 "tenantId": data.azurerm_subscription.subscription.tenant_id,
                                 "clientId": azuread_application.bridgecrew_app.application_id,
-                                "clientSecret": random_string.password.result}})}'
+                                "clientSecret": random_string.password.result}})}"
     CURL
   }
 


### PR DESCRIPTION
A user reported the following issue with the module. I believe this occurs on windows machines due to single-quotes being used in the curl command in the local-exec block. 

Here's an SO thread that explains this: https://stackoverflow.com/questions/6884669/curl-1-protocol-https-not-supported-or-disabled-in-libcurl

```
Error: local-exec provisioner error
│
│ with module.bridgecrew-read.null_resource.notify_bridgecrew,
│ on .terraform\modules\bridgecrew-read\main.tf line 67, in resource "null_resource" "notify_bridgecrew":
│ 67: provisioner "local-exec" {
│
│ Error running command ' curl --request PUT 'https://www.bridgecrew.cloud/api/v1/integrations/csp' \
│ --header 'Authorization: c2e1aac1-158a-571f-9fb7-84efc3528461' \
│ --header 'Content-Type: application/json' \
│ --data-raw '{"credentials":{"clientId":"34504c20-bbb7-4230-a9db-17ea6d72d78d","clientSecret":"4EasXudZkP3J1SAgKibVjm1A","subscriptionId":"d9da86e1-7cc1-406a-8492-501fffbc33fe","subscriptionName":"SSB Enterprise","tenantId":"c576ab0a-900c-44cd-aaa6-8eb91d5f04bc"},"customerName":"ssbinfo","version":"0.2.1"}'
│ ': exit status 6. Output: curl: (1) Protocol "'https" not supported or disabled in libcurl
│ % Total % Received % Xferd Average Speed Time Time Time Current
│ Dload Upload Total Spent Left Speed
```