### PR TITLE
Do not pin exact dependency versions

### DIFF
--- a/terraform.tf
+++ b/terraform.tf
@@ -1,17 +1,17 @@
 terraform {
   required_providers {
     azurerm = {
-      version = "2.53.0"
+      version = ">=2.53.0"
       source  = "hashicorp/azurerm"
     }
 
-    random = { version = "3.1.0"
+    random = { version = ">=3.1.0"
     source = "hashicorp/random" }
 
-    azuread = { version = "1.4.0"
+    azuread = { version = ">=1.4.0"
     source = "hashicorp/azuread" }
 
-    null = { version = "3.1.0"
+    null = { version = ">=3.1.0"
     source = "hashicorp/null" }
 
   }


### PR DESCRIPTION
Set greater than dependencies rather than exactly pinned versions.

We're running into the following error updating this module
```
│ Error: Failed to query available provider packages
│
│ Could not retrieve the list of available versions for provider hashicorp/azurerm: no available releases match the
│ given constraints 2.53.0, >= 2.68.0
```
We're unable to downgrade azurerm as the newer version has fixes that we
need. And in general we would prefer not being forced to use specific
versions by what's pinned by bridgecrew.