### PR TITLE
change extra role name to variable

### DIFF
--- a/azurerm_role_definition.tf
+++ b/azurerm_role_definition.tf
@@ -1,5 +1,5 @@
 resource "azurerm_role_definition" "extra_read_permissions" {
-  name  = "bridgecrew-extra-read-permissions"
+  name  = var.extra_read_permissions_role_name
   scope = data.azurerm_subscription.subscription.id
 
   permissions {

--- a/variables.tf
+++ b/variables.tf
@@ -16,7 +16,7 @@ variable "subscription_id" {
 }
 
 variable "extra_read_permissions_role_name" {
-  type = string
-  default = "bridgecrew-extra-read-permissions"
+  type        = string
+  default     = "bridgecrew-extra-read-permissions"
   description = "The name of the role that provides a few extra scanning permissions. You may need to provide a new name if you have multiple subscriptions sharing the same AD backend."
 }

--- a/variables.tf
+++ b/variables.tf
@@ -14,3 +14,9 @@ variable "subscription_id" {
   description = "The subscription to connect. If left unspecified, the default subscription will be taken"
   default     = null
 }
+
+variable "extra_read_permissions_role_name" {
+  type = string
+  default = "bridgecrew-extra-read-permissions"
+  description = "The name of the role that provides a few extra scanning permissions. You may need to provide a new name if you have multiple subscriptions sharing the same AD backend."
+}


### PR DESCRIPTION
Makes the extra role name a variable, so that users can supply a different name in the case that multiple subs share the same AD backend, but importing between states is not an option.